### PR TITLE
Change condition for env files in gitignore

### DIFF
--- a/resources/.gitignore-template
+++ b/resources/.gitignore-template
@@ -30,7 +30,7 @@ ansible/*.retry
 cmake-build-*/
 
 ### Env files ###
-*.env
+*.env*
 
 ### Intellij+all Patch ###
 # Ignores the whole .idea folder and all .iml files


### PR DESCRIPTION
Summary:
user-interface-mypage creates a .env.js file for example which gets tracked. There are several .env.* in the old gitignore used there

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
