### PR TITLE
Add elhub-mvn repo to pluginManagement repositories

### DIFF
--- a/resources/gradleFiles/settings.gradle.kts
+++ b/resources/gradleFiles/settings.gradle.kts
@@ -2,7 +2,8 @@ rootProject.name = "your-project-name"
 
 pluginManagement {
     repositories {
-        maven(url = "https://jfrog.elhub.cloud:443/artifactory/elhub-plugins")
+        maven("https://jfrog.elhub.cloud:443/artifactory/elhub-mvn")
+        maven("https://jfrog.elhub.cloud:443/artifactory/elhub-plugins")
     }
 }
 


### PR DESCRIPTION
## 📝 Description

Some of the stuff needed for the elhub-gradle-plugin is not in the elhub-plugins repository.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
