### PR TITLE
Add gradlew to .gitattributes to remove windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Force the following filetypes to have unix eols, so Windows does not break them
 *.* text eol=lf
+gradlew text eol=lf
 
 # Explicit windows files should use crlf
 *.bat text eol=crlf


### PR DESCRIPTION
## 📝 Description

I found that the windows line endings broke running ./gradlew in some projects. This should hopefully fix that problem.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
