### PR TITLE
Unset max-line-length for JSON files

### DIFF
--- a/resources/.editorconfig-template
+++ b/resources/.editorconfig-template
@@ -18,6 +18,9 @@ indent_size = 4
 [*.{java,scala,rs,xml}]
 indent_size = 4
 
+[*.{json}]
+max_line_length = unset
+
 [*.{kt,kts}]
 indent_size = 4
 ktlint_code_style = intellij_idea


### PR DESCRIPTION
## 📝 Description

JSON is a machine format, not a format primarily intended for human usage. The 160
char limit is unnecessarily restricting for JSON files, in addition to which JSON
has no real mechanisms for line breaks. The restriction should not exist for JSON.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
