### PR TITLE
Remove indent_size rule from 'All Files'

### DIFF
--- a/resources/.editorconfig-template
+++ b/resources/.editorconfig-template
@@ -8,7 +8,6 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
## 📝 Description

With this rule, we end up scanning a number of generated files (for instance gradlew) which fail this and are out of our control. indent_size should therefore be specified on a filetype-to-filetype basis

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
