### PR TITLE
Update devxp-build-configuration version

### DIFF
--- a/resources/.teamcity/pom-template.xml
+++ b/resources/.teamcity/pom-template.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <devxp-build-configuration.version>1.24.22</devxp-build-configuration.version>
+        <devxp-build-configuration.version>1.29.6</devxp-build-configuration.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Noticed this version was out of date when running our gh command `gh dxp template init` 😋

PS: PR for enabling Renovate for this repo will soon come! 