### PR TITLE
chore: remove ktlint params from editorconfig template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Git
-[{.gitmodules}]
+[.gitmodules]
 indent_style = tab
 
 # Go
@@ -48,6 +48,7 @@ ktlint_standard_class-signature = disabled
 # This ends up correcting to something that intellij auto-formats back
 ktlint_standard_condition-wrapping = disabled
 max_line_length = 160
+ij_continuation_indent_size = 4
 
 # Makefile
 [{Makefile,**.mk}]

--- a/resources/.editorconfig-template
+++ b/resources/.editorconfig-template
@@ -31,22 +31,6 @@ indent_size = 2
 
 # Kotlin
 [*.{kt,kts}]
-ktlint_code_style = intellij_idea
-ktlint_standard_max-line-length = 160
-ktlint_standard = enabled
-# Disable Ktlint rules
-ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than=unset
-ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
-ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
-ktlint_standard_string-template-indent = disabled
-ktlint_standard_trailing-comma-on-call-site = disabled
-ktlint_standard_trailing-comma-on-declaration-site = disabled
-# These two rules are too strict on whether parameters can be on multiple lines even though they could potentially fit on one line.
-# Can't find a more specific rule to disable.
-ktlint_standard_function-signature = disabled
-ktlint_standard_class-signature = disabled
-# This ends up correcting to something that intellij auto-formats back
-ktlint_standard_condition-wrapping = disabled
 max_line_length = 160
 ij_continuation_indent_size = 4
 


### PR DESCRIPTION
## 📝 Description

A different editorconfig file is used for linting with ktlint, so there is no need to have them here

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
